### PR TITLE
Removed duplicate `-t` in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ YouTrack starts and listens on port 80 in the container.
 To map it to the host's port 80, use the following command to create and start the container instead:
 
 ```bash
-docker run -t --name youtrack -p 80:80 -t uniplug/youtrack
+docker run -t --name youtrack -p 80:80 uniplug/youtrack
 ```
 
 To access container logs


### PR DESCRIPTION
Removed the duplicate `-t` in `docker run -t --name youtrack -p 80:80 -t uniplug/youtrack`. Possibly could update `-t` to `-ti` if your going for "terminal interactive".